### PR TITLE
Fix arguable typos in permissions.md

### DIFF
--- a/assets/texts/en/permissions.md
+++ b/assets/texts/en/permissions.md
@@ -4,7 +4,7 @@ For a general explanation of add-on permission see [this support article](https:
 
 ## Installation permissions
 
-Currently no permissions are requested at the installation or when updating.
+Currently, no permission is requested at the installation or when updating.
 
 ## Feature-specific (optional) permissions
 
@@ -16,7 +16,7 @@ These permissions are requested when doing some specific actions, if they are ne
 
 ## Hidden permissions
 
-Additionally it requests these permission, which are not requested in Firefox when the add-on is installed, as they are not a serious permission.
+Additionally, it requests these permissions, which are not requested in Firefox when the add-on is installed, as they are not a serious permission.
 
 | Internal Id | Permission           | Explanation               |
 |:------------|:---------------------|:--------------------------|


### PR DESCRIPTION
Additionally, we could change "these permissions" instances to "this permission" when adapted, but it would require addenda to revert it back.