### PR TITLE
Update .eslintrc to add keyword-spacing rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,9 @@
             "allowTemplateLiterals": false
         }],
         "brace-style": 2,
+        "keyword-spacing": ["error", {
+            "after": true
+        }],
 
         // just to make sure (are defaults)
         "indent": ["error", 4],


### PR DESCRIPTION
As suggested here: https://github.com/rugk/mastodon-simplified-federation/pull/84/files/bf2360f32b7d5b4d5fbf0e4e141eabbe086f505c#r1029858195